### PR TITLE
switch from ts-node to tsx and simplify

### DIFF
--- a/js/metadatablocks/README.md
+++ b/js/metadatablocks/README.md
@@ -2,15 +2,13 @@
 
 This directory contains JavaScript/TypeScript recipes for working with Dataverse metadata blocks. These tools help you interact with, analyze, and manage metadata schemas across different Dataverse instances.
 
-> [!IMPORTANT]  
-> These scripts require `ts-node` and `node>=20.0.0` to execute TypeScript files directly. Install `ts-node` and `node` globally with:
->
-> ```bash
-> npm install -g ts-node
-> nvm install 20 # or your desired version >= 20.0.0
-> ```
->
-> Alternatively, you can use `npx ts-node <script>.ts` instead of installing globally. We recommend a global installation for convenience.
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
 
 ## Available Recipes
 
@@ -30,7 +28,7 @@ npm run list:demo -- --output metadata-blocks.json
 npm run list:demo -- --api-token your-token --output local-blocks.json
 
 # Direct usage with custom URL
-npm run list -- --base-url https://your-dataverse.org/api/v1
+npx tsx list.ts --base-url https://your-dataverse.org/api/v1
 ```
 
 **Options:**
@@ -40,23 +38,8 @@ npm run list -- --base-url https://your-dataverse.org/api/v1
 - `-o, --output <file>`: Save output to file instead of console (optional)
 - `-h, --help`: Show help information
 
-## Getting Started
-
-1. Install dependencies:
-
-   ```bash
-   npm install
-   ```
-
-2. Run any of the available scripts:
-
-   ```bash
-   npm run list:demo
-   ```
-
 ## Requirements
 
 - Node.js `>= 20.0.0`
 - TypeScript
-- ts-node
 - Access to a Dataverse instance

--- a/js/metadatablocks/list.ts
+++ b/js/metadatablocks/list.ts
@@ -5,9 +5,9 @@
  * It can output the results to the console or save them to a JSON file.
  * 
  * Usage:
- *   ts-node list.ts -b https://demo.dataverse.org/api/v1
- *   ts-node list.ts -b https://demo.dataverse.org/api/v1 -a your-api-token
- *   ts-node list.ts -b https://demo.dataverse.org/api/v1 -o metadata-blocks.json
+ *   npx tsx list.ts -b https://demo.dataverse.org/api/v1
+ *   npx tsx list.ts -b https://demo.dataverse.org/api/v1 -a your-api-token
+ *   npx tsx list.ts -b https://demo.dataverse.org/api/v1 -o metadata-blocks.json
  */
 
 import { ApiConfig, getAllMetadataBlocks, MetadataBlock, } from '@iqss/dataverse-client-javascript'

--- a/js/metadatablocks/package.json
+++ b/js/metadatablocks/package.json
@@ -10,9 +10,9 @@
   "devDependencies": {
     "@types/node": "^24.3.1"
   },
-    "scripts": {
-        "list": "ts-node list.ts",
-        "list:demo": "ts-node list.ts -b https://demo.dataverse.org/api/v1",
-        "list:local": "ts-node list.ts -b http://localhost:8080/api/v1"
-    }
+  "scripts": {
+    "list": "npx tsx list.ts",
+    "list:demo": "npx tsx list.ts -b https://demo.dataverse.org/api/v1",
+    "list:local": "npx tsx list.ts -b http://localhost:8080/api/v1"
+  }
 }


### PR DESCRIPTION
ts-node is not regularly maintained and this issue recommends switching to [tsx](https://tsx.is):

- https://github.com/TypeStrong/ts-node/issues/2140

In this PR, I'm proposing we switch to tsx. As a nice side effect, the README is simplified.

I'm using the latest node TLS, which is node 22, so I'm not actually sure what the minimum requirement is. I left it at 20.